### PR TITLE
fix for mouse without serial number

### DIFF
--- a/src/PointerEngine.ts
+++ b/src/PointerEngine.ts
@@ -106,8 +106,9 @@ export class PointerEngine extends BaseObserver<PointerEngineListener> {
   refreshDeviceList() {
     this.logger.info('Refreshing device list');
     let pointerDevices = _.filter(devices(), (d) => d.usage === 2 && d.usagePage === 1);
-    let unique = _.uniqBy(pointerDevices, (u) => u.serialNumber);
-
+    const uniqueByProduct = _.uniqBy(pointerDevices.filter(item => !item.serialNumber), 'product');
+    const uniqueBySerialNumber = _.uniqBy(pointerDevices.filter(item => item.serialNumber), 'serialNumber');
+    let unique = [...uniqueByProduct, ...uniqueBySerialNumber];
     const snMapper = (a: PointerDevice | Device) => {
       if (a instanceof PointerDevice) {
         return a.sn;

--- a/src/PointerEngine.ts
+++ b/src/PointerEngine.ts
@@ -106,15 +106,7 @@ export class PointerEngine extends BaseObserver<PointerEngineListener> {
   refreshDeviceList() {
     this.logger.info('Refreshing device list');
     let pointerDevices = _.filter(devices(), (d) => d.usage === 2 && d.usagePage === 1);
-    const uniqueByProduct = _.uniqBy(
-      pointerDevices.filter((item) => !item.serialNumber),
-      'product'
-    );
-    const uniqueBySerialNumber = _.uniqBy(
-      pointerDevices.filter((item) => item.serialNumber),
-      'serialNumber'
-    );
-    let unique = [...uniqueByProduct, ...uniqueBySerialNumber];
+    let unique = _.uniqBy(pointerDevices, (u) => u.serialNumber || u.product);
     const snMapper = (a: PointerDevice | Device) => {
       if (a instanceof PointerDevice) {
         return a.sn;

--- a/src/PointerEngine.ts
+++ b/src/PointerEngine.ts
@@ -106,8 +106,14 @@ export class PointerEngine extends BaseObserver<PointerEngineListener> {
   refreshDeviceList() {
     this.logger.info('Refreshing device list');
     let pointerDevices = _.filter(devices(), (d) => d.usage === 2 && d.usagePage === 1);
-    const uniqueByProduct = _.uniqBy(pointerDevices.filter(item => !item.serialNumber), 'product');
-    const uniqueBySerialNumber = _.uniqBy(pointerDevices.filter(item => item.serialNumber), 'serialNumber');
+    const uniqueByProduct = _.uniqBy(
+      pointerDevices.filter((item) => !item.serialNumber),
+      'product'
+    );
+    const uniqueBySerialNumber = _.uniqBy(
+      pointerDevices.filter((item) => item.serialNumber),
+      'serialNumber'
+    );
     let unique = [...uniqueByProduct, ...uniqueBySerialNumber];
     const snMapper = (a: PointerDevice | Device) => {
       if (a instanceof PointerDevice) {


### PR DESCRIPTION
This PR improves the logic for identifying unique pointer devices (e.g., mice) by handling cases where devices do not provide a serial number.